### PR TITLE
Fix wrong pinout for 2nd I2C bus

### DIFF
--- a/esp32_s3_box_3/board_pins_config.c
+++ b/esp32_s3_box_3/board_pins_config.c
@@ -35,9 +35,12 @@ static const char *TAG = "ESP32_S3_BOX_3";
 
 esp_err_t get_i2c_pins(i2c_port_t port, i2c_config_t *i2c_config) {
   AUDIO_NULL_CHECK(TAG, i2c_config, return ESP_FAIL);
-  if (port == I2C_NUM_0 || port == I2C_NUM_1) {
+  if (port == I2C_NUM_0) {
     i2c_config->sda_io_num = GPIO_NUM_8;
     i2c_config->scl_io_num = GPIO_NUM_18;
+  } else if (port == I2C_NUM_1) {
+    i2c_config->sda_io_num = GPIO_NUM_41;
+    i2c_config->scl_io_num = GPIO_NUM_40;
   } else {
     i2c_config->sda_io_num = -1;
     i2c_config->scl_io_num = -1;


### PR DESCRIPTION
The ESP32-S3 box 3 uses 2 I2C ports, one on GPIO 8/18 and the other on GPIO 40/41. The fix allows to use the second port that's connected to sensors like AHT30 and radar. 

Currently, even when declaring the I2C GPIO in the YAML file, this function changes the GPIO number for the second port **after** ESPHome had set them, which is wrong and prevent the I2C bus from working.